### PR TITLE
feat: improve subtitle processing operations

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,6 +1,5 @@
 import path from "path";
 import { fileURLToPath } from "url";
-import { targetLangMap } from "./translateSentence.js";
 
 // Helper to get the directory name in ES module context
 export const __filename = fileURLToPath(import.meta.url);
@@ -10,12 +9,4 @@ export const subtitlesFolder = path.join(__dirname, "../subtitles");
 // Helper to resolve the absolute path
 export const getFilePath = (relativePath: string): string => {
   return path.resolve(__dirname, relativePath);
-};
-
-export const shuffleArray = <T>(array: T[]): T[] => {
-  for (let i = array.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
-    [array[i], array[j]] = [array[j], array[i]]; // Swap elements
-  }
-  return array;
 };

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,6 +1,6 @@
 import { Router, Request, Response } from "express";
 import { PrismaClient } from "@prisma/client";
-import { getSentence } from "./utils.js";
+import { getRandomSentenceFromSubtitle } from "./utils.js";
 import { sendEmail } from "./mailjet.js";
 import { __filename, __dirname } from "./helpers.js";
 import { SHOW_FILE_PATH } from "./types.js";
@@ -94,8 +94,10 @@ router.post("/submit-data", async (req: Request, res: Response) => {
       });
     }
 
-    // Fetch subtitle based on favoriteShow TODO: implement different target language
-    const sentence = await getSentence(filePath, proficiencyLevel);
+    const sentence = await getRandomSentenceFromSubtitle(
+      filePath,
+      proficiencyLevel
+    );
 
     if (!sentence) {
       return res.status(404).json({ error: "Subtitle not found" });

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,3 +5,19 @@ export const SHOW_FILE_PATH: ShowFilePathMap = new Map([
   ["Station 19-it", "../subtitles/station-19-s01e01-it.srt"],
   ["9-1-1-en", "../subtitles/9-1-1-s08e01-en.srt"],
 ]);
+
+export type ProficiencyLevel = "beginner" | "intermediate";
+
+export type Threshold = {
+  maxLength: number;
+  maxComplexWords: number;
+  minLength?: number;
+};
+
+export type AnalyzedSentence = {
+  terms: string[];
+  nouns: string[];
+  verbs: string[];
+  complements: string[];
+  conjunctions: string[];
+};


### PR DESCRIPTION
In this PR:

- using streams to read the subtitles for memory efficiency
- reducing parsing and analysis 
- simplifying sentence filtering by merging filtering by proficiencyLevel and adding pre-filtering (no analysis for sentences that don't match the threshold) and concurrency via Promise.all
- using the power of async operations :)
- used console.time/timeEnd to identify bottlenecks, brought filterSentences from 1.086s down to 430.014ms.